### PR TITLE
Run build workflows for automatic PRs

### DIFF
--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  GH_TOKEN: ${{ secrets.NEW_PR_TOKEN }}
 
 jobs:
   check_deps:

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -2,6 +2,9 @@
 
 if [[ -n ${RUNNER_DEBUG} ]]; then
     set -x
+    echo "======== Start Environment ==========="
+    env
+    echo "========  End Environment  ==========="
 fi
 
 set -Eeuo pipefail


### PR DESCRIPTION
It looks like we must use a Classic Personal Acces token to be able to
create a PR for which Github will automatically trigger workflows,
like the Build workflow.

Also print the environment when debug is enabled.