### PR TITLE
Update GH actions version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout build scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Read build.env
         id: buildenv
         uses: falti/dotenv-action@v1
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get -y install build-essential emacs-bin-common check
           sudo apt-get -y install libzstd-dev libssl-dev=${{env.OPENSSL_VERSION}} libtls-dev=${{env.LIBTLS_VERSION}}
       - name: Checkout libfixposix
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: sionescu/libfixposix
           ref: "v${{env.LIBFIXPOSIX_VERSION}}"
@@ -61,7 +61,7 @@ jobs:
       - name: Fetch SBCL host
         run: scripts/fetch_sbcl_host.sh "${{env.SBCL_HOST_VERSION}}"
       - name: Checkout SBCL
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: sbcl/sbcl
           ref: "sbcl-${{env.SBCL_VERSION}}"
@@ -71,7 +71,7 @@ jobs:
       - name: Build SBCL
         run: scripts/build_sbcl.sh "${{env.SBCL_HOST}}" "${{env.SBCL_VERSION}}" "${{env.REVISION}}" "${{env.CUSTOM_LIBDIR}}"
       - name: 'Upload Artifacts'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tarballs
           path: |
@@ -85,7 +85,7 @@ jobs:
     if: github.ref_name == 'master'
     steps:
       - name: Checkout build scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Read build.env
         id: buildenv
         uses: falti/dotenv-action@v1
@@ -102,7 +102,7 @@ jobs:
           echo "LIBTLS_VERSION=${{steps.buildenv.outputs.libtls_version}}" >> ${GITHUB_ENV}
           echo "REVISION=${{steps.buildenv.outputs.revision}}" >> ${GITHUB_ENV}
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: tarballs
       - name: Upload release

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout build scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Read build.env
         id: buildenv
         uses: falti/dotenv-action@v1


### PR DESCRIPTION
Update `checkout`, `upload-artifact` and `download-artifact` from `@v4` to `@v5`.